### PR TITLE
【Fixed】add,improve:juice_managerのテスト追加し、accountantの不要コメント削除

### DIFF
--- a/accountant.rb
+++ b/accountant.rb
@@ -4,7 +4,6 @@ class Accountant
   def initialize(cash, juice_manager)
     @cash = cash
     @juice_manager = juice_manager
-    # @juices = stock.juices # 本来こちらで持つべきではない
   end
 
   # 投入金額の総計取得用
@@ -21,7 +20,7 @@ class Accountant
   # 使用できるお金であれ投入金額に加算
   # 想定外のものは投入金額に加算せず、returnする
   def insert_money(money)
-    return money unless @cash.useful?(money) # これもcashにmethod useful?とか作れば良いかも
+    return money unless @cash.useful?(money)
     @cash.amount_money += money
     return
   end
@@ -41,7 +40,6 @@ class Accountant
 
   # 購入できる場合は、ジュースとお釣りを返す
   def purchase(juice)
-    juice = juice.to_sym
     if self.purchasable?(juice)
       price = @juice_manager.price(juice)
       @juice_manager.retrieve(juice)
@@ -51,8 +49,7 @@ class Accountant
     end
   end
 
-  # 購入可能なドリンクのリストを出す。戻り値：Array [:coke, :water]
-  # これはstockのメソッドとして作った方が良い引数にamonut_moneyを入れる
+  # 購入可能なドリンクのリストを出す。
   def purchasable_list(money)
     @juice_manager.purchasable_list(money)
   end

--- a/test/juice_manager_test.rb
+++ b/test/juice_manager_test.rb
@@ -1,0 +1,60 @@
+require "minitest/autorun"
+require_relative "../juice_manager"
+
+class JuiceManagerTest < Minitest::Test
+  def setup
+    @jm = JuiceManager.new
+  end
+
+  # stockメソッドのテストです
+  def test_stock_when_juice_exists
+    assert_equal 5, @jm.stock(:coke)
+  end
+  def test_stock_when_juice_does_not_exist
+    # 戻り値がnilとなるが、0の方が良いのか？
+    assert_nil @jm.stock("orange")
+  end
+
+  # storeメソッドのテストstockメソッドを利用している
+  def test_store_when_juice_exists
+    @jm.store(:coke, 120, 5)
+    assert_equal 10, @jm.stock(:coke)
+  end
+  def test_store_when_juice_does_not_exist
+    @jm.store("orange", 110, 1)
+    assert_equal 1, @jm.stock(:orange)
+  end
+
+  # priceメソッドのテスト
+  def test_price_when_juice_exists
+    assert_equal 120, @jm.price(:coke)
+  end
+  def test_price_when_juice_not_exists
+    assert_nil @jm.price(:orange)
+  end
+
+  # purchasable?メソッドのテスト, 戻り値はboolean型
+  def test_purchasable_when_juice_exists_and_enough_money
+    assert @jm.purchasable?(:coke, 130)
+  end
+  def test_purchasable_when_juice_exists_and_insufficient_money
+    refute @jm.purchasable?(:coke, 100)
+  end
+  def test_purchasable_when_juice_exists_and_insufficient_stock
+    @jm.store(:coke, 120, -5)
+    assert_equal 0, @jm.stock(:coke)
+    refute @jm.purchasable?(:coke, 130)
+  end
+  def test_purchasable_when_juice_does_not_exist_and_enough_money
+    # これがエラーになる
+    refute @jm.purchasable?(:orange, 1000)
+  end
+
+  # purchasable_listのテスト
+  def test_purchasable_list_when_enough_money
+    assert_equal %i[ coke water ], @jm.purchasable_list(120).sort
+  end
+  def test_purchasable_list_when_insufficient_money
+    assert_empty @jm.purchasable_list(90)
+  end
+end


### PR DESCRIPTION
- [x] juice_managerのテストコード追加しました
- [x] accountantの不要コメント削除
- [x] accountant側では、juice.to_symは不要と判断し削除（juice_manager側で対応してもらっているため）