### PR TITLE
【Fixed:マージはしないで】VendingMachineを修正

### DIFF
--- a/vending_machine.rb
+++ b/vending_machine.rb
@@ -95,3 +95,5 @@ class VendingMachine
     @accountant.sale_amount
   end
 end
+
+VendingMachine.start

--- a/vending_machine.rb
+++ b/vending_machine.rb
@@ -1,109 +1,98 @@
+require_relative "./accountant.rb"
+require_relative "./juice_manager.rb"
+require_relative "./cash.rb"
+
 class VendingMachine
-  attr_reader :amount_money, :sale_amount
-  # ステップ０　お金の投入と払い戻しの例コード
-  # ステップ１　扱えないお金の例コード
+  def self.start
+    @cash = Cash.new
+    @juice_manager = JuiceManager.new
+    @accountant = Accountant.new(@cash, @juice_manager)
 
-  # 10円玉、50円玉、100円玉、500円玉、1000円札を１つずつ投入できる。
-  MONEY = [10, 50, 100, 500, 1000].freeze
-
-  # （自動販売機に投入された金額をインスタンス変数の @insert_money に代入する）
-  def initialize
-    # 最初の自動販売機に入っている金額は0円
-    @amount_money = 0
-    @sale_amount = 0
-    @juices = {coke: {name: "コーラ", price: 120, stock: 5}}
+    while true
+      puts "あなたは何をするか決めてください"
+      puts "1:購入、2:管理業務"
+      action = gets.chomp.to_s
+      if ["1", "2"].include?(action)
+        if action == "1"
+          choice
+        else
+          management
+        end
+        return
+      else
+        puts "1か2を選択下さい"
+      end
+    end  
   end
 
-  # 10円玉、50円玉、100円玉、500円玉、1000円札を１つずつ投入できる。
-  # 投入は複数回できる。
-  def insert_money(money)
-    # puts "#{money}を投入"
-    # 想定外のもの（１円玉や５円玉。千円札以外のお札、そもそもお金じゃないもの（数字以外のもの）など）
-    # が投入された場合は、投入金額に加算せず、それをそのまま釣り銭としてユーザに出力する。
-    return puts "#{money}を返却します。" unless MONEY.include?(money)
-    # 自動販売機にお金を入れる
-    @amount_money += money
-  end
-
-  # 払い戻し操作を行うと、投入金額の総計を釣り銭として出力する。
-  def refund_money
-    # 返すお金の金額を表示する
-    puts @amout_money
-    # 自動販売機に入っているお金を0円に戻す
-    @amout_money = 0
-  end
-
-  def juice_management
-    # (0...@juices.length).each do |i|
-    #     puts "#{juices.keys[i]}は#{juices.values[i][:price]}円で在庫は#{juice.values[i][:stock]}本です。"
-    # end
-    @juices.each do |key,hash|
-      puts "#{hash[:name]}は#{hash[:price]}円で在庫は#{hash[:stock]}本です。"
+  def self.choice
+    while true
+      puts "何をしますか？"
+      puts "1:お金を投入、2:払い戻し、3:購入する"
+      puts "購入可能リスト"
+      p @accountant.purchasable_list(@cash.amount_money).map{|i| i = i.to_s}
+      action = gets.chomp.to_s
+      ["1", "2", "3"].include?(action)
+      if action == "1"
+        insert
+      elsif action == "2"
+        return refund
+      elsif action == "3"
+        return purchase
+      else
+        puts "1～3を選択ください"
+      end
     end
-
   end
 
-  def purchasable?(juice)
-    juice = juice.to_sym
-    if @juices[juice]
-      @juices[juice][:stock] !=0 && @juices[juice][:price] <= @amount_money
+  def self.management
+    while true
+      puts "何をしますか？"
+      puts "1:商品追加、2:商品リスト表示、3:終了"
+      action = gets.chomp.to_s
+      ["1", "2", "3"].include?(action)
+      if action == "1"
+        puts "aaa"
+      elsif action == "2"
+        puts @juice_manager.juices
+      elsif action == "3"
+        return puts "終了します。"
+      else
+        puts "1～3を選択ください"
+      end
+    end
+  end
+
+  def self.insert
+    puts "投入金額を決めてください。"
+    puts "対応可能硬貨： #{Cash::MONEY}"
+    money = gets.to_i
+      @accountant.insert_money(money)
+      puts @cash.amount_money
+  end
+
+  def self.refund
+    puts "#{@cash.amount_money}円を返却します。"
+    @cash.amount_money = 0
+  end
+
+  def self.purchase
+    puts "購入可能リストは下記の通りです。"
+    p @accountant.purchasable_list(@cash.amount_money).map{|i| i = i.to_s}
+    puts "何を購入しますか？"
+    juice = gets.chomp
+    if @accountant.purchasable?(juice)
+      @accountant.purchase(juice)
+      puts "#{juice}を購入しました"
+      refund
+      puts @cash.amount_money #おつりが出力されない
+      puts @cash.sale_amount
     else
-      false
+      puts "購入できません"
+      choice
     end
   end
 
-  def purchasable_list
-    #購入可能なドリンクのリストを出す。戻り値：Array [:coke, :water]
-    @juices.keys.select{|juice| purchasable?(juice)}
-  end
-
-  def store(juice, name, price, stock)
-    # @juicesに追加される　戻り値なし
-    if @juices[juice.to_sym]
-      @juices[juice.to_sym][:stock] += stock
-    else
-      @juices[juice.to_sym] = {name: name, price: price, stock: stock}
-    end
-  end
-
-  def purchase(juice)
-    if self.purchasable?(juice)
-      buy_juice = @juices[:"#{juice}"][:price]
-      @amount_money -= buy_juice
-      @sale_amount += buy_juice
-      @juices[:"#{juice}"][:stock] -= 1
-    end
-  end
 end
 
-if __FILE__ == $0
-  vm = VendingMachine.new
-  # vm.juice_management
-  vm.insert_money 100
-  vm.insert_money 10
-  vm.insert_money 10
-  # vm.purchase(:coke)
-  # puts vm.amount_money
-  # puts vm.sale_amount
-  vm.juice_management
-  vm.store(:water, "水", 100, 5)
-  vm.juice_management
-  vm.store(:coke, "コーラ", 120, 5)
-  vm.juice_management
-  vm.store(:water, "水", 100, 5)
-  vm.juice_management
-  p vm.purchasable_list
-  # return vm.purchasable?(:cola)
-  # # -> true, false
-  # return vm.purchase(:cola) # <- purchasableを使う
-  # # -> true, false
-
-# ジュースを3種類管理できるようにする。
-
-# 在庫にレッドブル（値段:200円、名前”レッドブル”）5本を追加する。
-
-# 在庫に水（値段:100円、名前”水”）5本を追加する。
-
-# 投入金額、在庫の点で購入可能なドリンクのリストを取得できる。
-
-end
+VendingMachine.start

--- a/vending_machine.rb
+++ b/vending_machine.rb
@@ -3,11 +3,11 @@ require_relative "./juice_manager.rb"
 require_relative "./cash.rb"
 
 class VendingMachine
-  def self.start
-    @cash = Cash.new
-    @juice_manager = JuiceManager.new
-    @accountant = Accountant.new(@cash, @juice_manager)
+  @cash = Cash.new
+  @juice_manager = JuiceManager.new
+  @accountant = Accountant.new(@cash, @juice_manager)
 
+  def self.start
     while true
       puts "あなたは何をするか決めてください"
       puts "1:購入、2:管理業務"
@@ -22,7 +22,7 @@ class VendingMachine
       else
         puts "1か2を選択下さい"
       end
-    end  
+    end
   end
 
   def self.choice
@@ -30,7 +30,7 @@ class VendingMachine
       puts "何をしますか？"
       puts "1:お金を投入、2:払い戻し、3:購入する"
       puts "購入可能リスト"
-      p @accountant.purchasable_list(@cash.amount_money).map{|i| i = i.to_s}
+      p @accountant.purchasable_list(@accountant.amount_money).map{|i| i = i.to_s}
       action = gets.chomp.to_s
       ["1", "2", "3"].include?(action)
       if action == "1"
@@ -68,31 +68,30 @@ class VendingMachine
     puts "対応可能硬貨： #{Cash::MONEY}"
     money = gets.to_i
       @accountant.insert_money(money)
-      puts @cash.amount_money
+      puts @accountant.amount_money
   end
 
   def self.refund
-    puts "#{@cash.amount_money}円を返却します。"
-    @cash.amount_money = 0
+    puts "#{@accountant.refund_money}円を返却します。"
   end
 
   def self.purchase
     puts "購入可能リストは下記の通りです。"
-    p @accountant.purchasable_list(@cash.amount_money).map{|i| i = i.to_s}
+    p @accountant.purchasable_list(@accountant.amount_money).map{|i| i = i.to_s}
     puts "何を購入しますか？"
     juice = gets.chomp
     if @accountant.purchasable?(juice)
-      @accountant.purchase(juice)
+      change = @accountant.purchase(juice) #購入操作は同時に返金も行われる
       puts "#{juice}を購入しました"
-      refund
-      puts @cash.amount_money #おつりが出力されない
-      puts @cash.sale_amount
+      puts "お釣りは#{change}"
+      puts "売上高は計#{@accountant.sale_amount}"
     else
       puts "購入できません"
       choice
     end
   end
 
+  def self.sale_amount
+    @accountant.sale_amount
+  end
 end
-
-VendingMachine.start


### PR DESCRIPTION
# 問題だった点
## Accountantクラスのメソッドの使い方
purchaseメソッドは、以下の作業をします。
- juice_managerの該当ジュースを1本引く
- cashのamount_moneyからジュース代を引く
- sale_amountに売上を計上
- お釣りを返す

従って、purchaseメソッドを呼び出した瞬間にamount_moneyは0になりますし、refound_moneyもその時動くので、後で呼び出してもお釣りは0になります。
これが主な原因です。
また、cashはaccountantが担当するため、直接VendingMachineが操作するのは禁止にしたほうが良いと思います（2ヶ所からのアクセスは規模が大きくなった時によろしくない気がします）。
そのために、accountantにラップする形でメソッドを作成しているので。